### PR TITLE
Adds nginx integrator related commits

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -36,6 +36,24 @@ applications:
     channel: "edge"
     scale: 1
 
+  ingress-sdlc:
+    charm: "nginx-ingress-integrator"
+    channel: "stable"
+    scale: 1
+    trust: true
+
+  ingress-engine:
+    charm: "nginx-ingress-integrator"
+    channel: "stable"
+    scale: 1
+    trust: true
+
+  ingress-studio:
+    charm: "nginx-ingress-integrator"
+    channel: "stable"
+    scale: 1
+    trust: true
+
 relations:
   # Legend DB relations:
   - ["legend-db", "mongodb"]
@@ -49,3 +67,7 @@ relations:
   # Legend component relations:
   - ["legend-studio", "legend-sdlc"]
   - ["legend-studio", "legend-engine"]
+  # Nginx Ingress Integrator relations:
+  - ["legend-sdlc", "ingress-sdlc"]
+  - ["legend-engine", "ingress-engine"]
+  - ["legend-studio", "ingress-studio"]

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -6,46 +6,46 @@ name: finos-legend-bundle
 bundle: kubernetes
 
 applications:
-  mongodb-k8s:
+  mongodb:
     charm: "mongodb-k8s"
     channel: "edge"
     scale: 1
 
-  finos-legend-db-k8s:
+  legend-db:
     charm: "finos-legend-db-k8s"
     channel: "edge"
     scale: 1
 
-  finos-legend-sdlc-k8s:
+  legend-sdlc:
     charm: "finos-legend-sdlc-k8s"
     channel: "edge"
     scale: 1
 
-  finos-legend-engine-k8s:
+  legend-engine:
     charm: "finos-legend-engine-k8s"
     channel: "edge"
     scale: 1
 
-  finos-legend-studio-k8s:
+  legend-studio:
     charm: "finos-legend-studio-k8s"
     channel: "edge"
     scale: 1
 
-  finos-legend-gitlab-integrator-k8s:
+  gitlab-integrator:
     charm: "finos-legend-gitlab-integrator-k8s"
     channel: "edge"
     scale: 1
 
 relations:
   # Legend DB relations:
-  - ["finos-legend-db-k8s", "mongodb-k8s"]
-  - ["finos-legend-sdlc-k8s", "finos-legend-db-k8s"]
-  - ["finos-legend-engine-k8s", "finos-legend-db-k8s"]
-  - ["finos-legend-studio-k8s", "finos-legend-db-k8s"]
+  - ["legend-db", "mongodb"]
+  - ["legend-sdlc", "legend-db"]
+  - ["legend-engine", "legend-db"]
+  - ["legend-studio", "legend-db"]
   # Legend GitLab relations:
-  - ["finos-legend-sdlc-k8s", "finos-legend-gitlab-integrator-k8s"]
-  - ["finos-legend-engine-k8s", "finos-legend-gitlab-integrator-k8s"]
-  - ["finos-legend-studio-k8s", "finos-legend-gitlab-integrator-k8s"]
+  - ["legend-sdlc", "gitlab-integrator"]
+  - ["legend-engine", "gitlab-integrator"]
+  - ["legend-studio", "gitlab-integrator"]
   # Legend component relations:
-  - ["finos-legend-studio-k8s", "finos-legend-sdlc-k8s"]
-  - ["finos-legend-studio-k8s", "finos-legend-engine-k8s"]
+  - ["legend-studio", "legend-sdlc"]
+  - ["legend-studio", "legend-engine"]

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -36,21 +36,9 @@ applications:
     channel: "edge"
     scale: 1
 
-  ingress-sdlc:
+  legend-ingress:
     charm: "nginx-ingress-integrator"
-    channel: "stable"
-    scale: 1
-    trust: true
-
-  ingress-engine:
-    charm: "nginx-ingress-integrator"
-    channel: "stable"
-    scale: 1
-    trust: true
-
-  ingress-studio:
-    charm: "nginx-ingress-integrator"
-    channel: "stable"
+    channel: "edge"
     scale: 1
     trust: true
 
@@ -68,6 +56,6 @@ relations:
   - ["legend-studio", "legend-sdlc"]
   - ["legend-studio", "legend-engine"]
   # Nginx Ingress Integrator relations:
-  - ["legend-sdlc", "ingress-sdlc"]
-  - ["legend-engine", "ingress-engine"]
-  - ["legend-studio", "ingress-studio"]
+  - ["legend-sdlc", "legend-ingress"]
+  - ["legend-engine", "legend-ingress"]
+  - ["legend-studio", "legend-ingress"]


### PR DESCRIPTION
Cherry-picked from: https://github.com/finos/legend-juju-bundle/pull/3
Cherry-picked from: https://github.com/finos/legend-juju-bundle/pull/5

Removes the ``finos-`` prefixes and ``-k8s`` suffixes from the application names, shortening them.

Recent changes to the nginx-ingress-integrator charm has made it possible to relate more than one charm to it, allowing it to
configure the necessary Kubernetes Resources for each relation.

Adds an ``nginx-ingress-integrator`` charm and adds a relation for each of the following Legend charms: SDLC, Engine, Studio.