### PR TITLE
Updates the bundle to have only one ingress charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -36,19 +36,7 @@ applications:
     channel: "stable"
     scale: 1
 
-  ingress-sdlc:
-    charm: "nginx-ingress-integrator"
-    channel: "stable"
-    scale: 1
-    trust: true
-
-  ingress-engine:
-    charm: "nginx-ingress-integrator"
-    channel: "stable"
-    scale: 1
-    trust: true
-
-  ingress-studio:
+  legend-ingress:
     charm: "nginx-ingress-integrator"
     channel: "stable"
     scale: 1
@@ -68,6 +56,6 @@ relations:
   - ["legend-studio", "legend-sdlc"]
   - ["legend-studio", "legend-engine"]
   # Nginx Ingress Integrator relations:
-  - ["legend-sdlc", "ingress-sdlc"]
-  - ["legend-engine", "ingress-engine"]
-  - ["legend-studio", "ingress-studio"]
+  - ["legend-sdlc", "legend-ingress"]
+  - ["legend-engine", "legend-ingress"]
+  - ["legend-studio", "legend-ingress"]


### PR DESCRIPTION
Recent changes to the ``nginx-ingress-integrator`` charm has made it possible to relate more than one charm to it, allowing it to
configure the necessary Kubernetes Resources for each relation.