### PR TITLE
Adds create branch github action

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,65 @@
+name: Create FINOS Legend release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'The release to create a branch for (yyyy-mm-dd)'
+        required: true
+
+jobs:
+  create-branch:
+    name: Create release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo snap install yq
+
+      - name: Update bundle.yaml
+        run: |
+          # Create an overlay yaml file with the desired release version for Legend Engine,
+          # SDLC, and Studio, and apply it over the bundle.yaml file.
+          echo "applications:" > overlay.yaml
+          echo "  legend-sdlc:" >> overlay.yaml
+          echo "    channel: ${{ github.event.inputs.release }}/edge" >> overlay.yaml
+          echo "  legend-engine:" >> overlay.yaml
+          echo "    channel: ${{ github.event.inputs.release }}/edge" >> overlay.yaml
+          echo "  legend-studio:" >> overlay.yaml
+          echo "    channel: ${{ github.event.inputs.release }}/edge" >> overlay.yaml
+
+          # We can't have bundle.yaml as both the source and destionation, the result will not be
+          # as we would have wanted it.
+          cp bundle.yaml bundle2.yaml
+          yq eval-all '. as $item ireduce ({}; . *+ $item)' bundle2.yaml overlay.yaml > bundle.yaml
+
+          cat bundle.yaml
+
+      - name: Create branch and commit
+        uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+        with:
+          # The arguments for the `git add` command (see the paragraph below for more info)
+          # Default: '.'
+          add: 'bundle.yaml'
+
+          # The name of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_name: Claudiu Belu
+
+          # The email of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_email: cbelu@cloudbasesolutions.com
+
+          # Additional arguments for the git commit command. The --message argument is already set by the message input.
+          # Default: ''
+          commit: --signoff
+
+          # The message for the commit.
+          # Default: 'Commit from GitHub Actions (name of the workflow)'
+          message: "Creates ${{ github.event.inputs.release }} release"
+
+          # If this input is set, the action will push the commit to a new branch with this name.
+          # Default: ''
+          new_branch: "release-${{ github.event.inputs.release }}"


### PR DESCRIPTION
This ``workflow_dispatch`` action will create a new branch with the given release name, and creates a commit in which it updates the bundle.yaml file to have the Legend Engine, SDLC, Studio charms point towards the given release channel.