### PR TITLE
Adds FINOS Legend Bundle Integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: FINOS Legend Bundle Test Jobs
+on: [pull_request, push, workflow_dispatch]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: python3 -m pip install tox
+
+      - name: Run linters
+        run: tox -vve lint
+
+  integration-test:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      - name: Setup operator environment
+        # TODO: change this to charmed-kubernetes/actions-operator@main once
+        # the following issue is addressed:
+        # https://github.com/charmed-kubernetes/actions-operator/issues/32
+        uses: claudiubelu/actions-operator@main
+        with:
+          provider: microk8s
+          microk8s-addons: "storage dns rbac ingress"
+
+      - name: Run integration tests
+        env:
+          GITLAB_CLIENT_ID: "${{ secrets.GITLAB_CLIENT_ID }}"
+          GITLAB_CLIENT_SECRET: "${{ secrets.GITLAB_CLIENT_SECRET }}"
+        run: |
+          tox -vve integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+
+# Linting tools configuration
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103"]
+docstring-convention = "google"
+# Check for properly formatted copyright header in each file
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+# Static analysis tools configuration
+[tool.mypy]
+pretty = true
+python_version = 3.8
+mypy_path = "$MYPY_CONFIG_FILE_DIR/tests/integration"
+follow_imports = "normal"
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+show_traceback = true
+show_error_codes = true
+namespace_packages = true
+explicit_package_bases = true
+check_untyped_defs = true
+allow_redefinition = true
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["ops.*", "kubernetes.*", "flatten_json.*"]
+ignore_missing_imports = true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module testing the FINOS Legend Bundle."""

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import os
+import sys
+
+import pytest
+import requests
+import tenacity
+from pytest_operator import plugin as pytest_plugin
+
+logger = logging.getLogger(__name__)
+
+BUNDLE_YAML = "./bundle.yaml"
+
+MONGODB_APP_NAME = "mongodb"
+ENGINE_APP_NAME = "legend-engine"
+SDLC_APP_NAME = "legend-sdlc"
+STUDIO_APP_NAME = "legend-studio"
+
+# TODO: Add STUDIO_APP_NAME to the list below once the following issue has been resolved:
+# https://github.com/finos/legend-studio/issues/1028
+LEGEND_APPS = [ENGINE_APP_NAME, SDLC_APP_NAME]
+LEGEND_APPS_CONFIG = [ENGINE_APP_NAME, SDLC_APP_NAME, STUDIO_APP_NAME]
+
+LEGEND_HOST = "legend-host"
+ANOTHER_LEGEND_HOST = "another-legend-host"
+
+APP_PORTS = {
+    ENGINE_APP_NAME: 6060,
+    SDLC_APP_NAME: 7070,
+    STUDIO_APP_NAME: 8080,
+}
+APP_ROUTES = {
+    ENGINE_APP_NAME: "/engine",
+    SDLC_APP_NAME: "/api",
+    STUDIO_APP_NAME: "/studio",
+}
+
+GITLAB_CLIENT_ID = os.getenv("GITLAB_CLIENT_ID")
+GITLAB_CLIENT_SECRET = os.getenv("GITLAB_CLIENT_SECRET")
+
+if not all([GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET]):
+    logger.fatal(
+        "Cannot run the integration tests without GITLAB_CLIENT_ID and GITLAB_CLIENT_SECRET "
+        "environment variables. They are required for the FINOS Legend authentication."
+    )
+    sys.exit(1)
+
+
+async def cli_deploy_bundle(ops_test, name):
+    run_args = [
+        "juju",
+        "deploy",
+        "--trust",
+        "--channel=edge",
+        "-m",
+        ops_test.model_full_name,
+        name,
+    ]
+
+    retcode, stdout, stderr = await ops_test.run(*run_args)
+    assert retcode == 0, "Deploy failed: %s" % (stderr or stdout).strip()
+    logger.info(stdout)
+
+
+# When the Ingress Routes are being established, it takes a few seconds to take effect, which
+# is why we should retry the connection a few times.
+@tenacity.retry(
+    retry=tenacity.retry_if_result(lambda x: x is False),
+    stop=tenacity.stop_after_attempt(10),
+    wait=tenacity.wait_exponential(multiplier=1, min=5, max=30),
+)
+def check_legend_connection(app_name, url, headers=None):
+    """Tests the connection to the given Legend URL.
+
+    When connecting to the FINOS Legend Applications, it will redirect to gitlab for
+    authentication, which will not be a 20X status code. We will receive 302 Found
+    instead.
+
+    Returns True if the response status code is 302, False in any other case.
+    """
+    logger.info("Trying to access %s...", app_name)
+    try:
+        response = requests.get(url, headers=headers, allow_redirects=False, timeout=10)
+        return response.status_code == 302
+    except Exception as ex:
+        logger.info(ex)
+
+    return False
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: pytest_plugin.OpsTest):
+    """Deploy the current FINOS Legend bundle.
+
+    Assert that the mongodb charm becomes active, since it takes the longest to become active.
+    """
+    # Deploy the bundle from CLI to avoid the charms getting stuck in the Waiting Status because
+    # the image docker.io/jujusolutions/charm-base:kubernetes-kubernetes could not be pulled.
+    await cli_deploy_bundle(ops_test, BUNDLE_YAML)
+
+    await ops_test.model.wait_for_idle(apps=[MONGODB_APP_NAME], status="active", timeout=2000)
+    assert ops_test.model.applications[MONGODB_APP_NAME].units[0].workload_status == "active"
+
+    # effectively disable the update status from firing
+    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+
+@pytest.mark.abort_on_fail
+async def test_config_gitlab(ops_test: pytest_plugin.OpsTest):
+    """Set the gitlab.com's application secret ID and name.
+
+    After setting the application secret ID and name, the charms should become active.
+    """
+    # We need valid information here. These should be passed in through the env variables.
+    gitlab_integrator = ops_test.model.applications["gitlab-integrator"]
+    await gitlab_integrator.set_config(
+        {"gitlab-client-id": GITLAB_CLIENT_ID, "gitlab-client-secret": GITLAB_CLIENT_SECRET}
+    )
+
+    # Wait for Legend Studio to become Active.
+    await ops_test.model.wait_for_idle(apps=[STUDIO_APP_NAME], status="active", timeout=1000)
+    assert ops_test.model.applications[STUDIO_APP_NAME].units[0].workload_status == "active"
+
+    # Assert that the right Callback URIs are being returned by the gitlab-integrator's
+    # get-redirect-uris action.
+    action = await gitlab_integrator.units[0].run_action("get-redirect-uris")
+    action = await action.wait()
+
+    expected_uris = [
+        "http://%s/engine/callback" % LEGEND_HOST,
+        "http://%s/api/auth/callback" % LEGEND_HOST,
+        "http://%s/api/pac4j/login/callback" % LEGEND_HOST,
+        "http://%s/studio/log.in/callback" % LEGEND_HOST,
+    ]
+
+    assert "completed" == action.data.get("status")
+    assert expected_uris == action.data.get("results").get("result", "").split("\n")
+
+
+@pytest.mark.abort_on_fail
+async def test_applications_are_up(ops_test: pytest_plugin.OpsTest):
+    """Test the direct FINOS Legend connection.
+
+    The FINOS Legend application services should be accessible through their IP, ports,
+    and routes.
+    """
+    status = await ops_test.model.get_status()
+
+    for app_name in LEGEND_APPS:
+        unit_name = "%s/0" % app_name
+        address = status["applications"][app_name]["units"][unit_name]["address"]
+
+        url = "http://%s:%s%s" % (address, APP_PORTS[app_name], APP_ROUTES[app_name])
+        can_connect = check_legend_connection(app_name, url)
+
+        assert can_connect, "Could not reach %s through its IP." % app_name
+        logger.info("Successfully reached %s through its IP.", app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_nginx_ingress_integration(ops_test: pytest_plugin.OpsTest):
+    """Test the FINOS Legend connection through NGINX Ingress.
+
+    The Legend applications have been configured with the legend-host external-hostname by default,
+    and they should be accessible through it due to the nginx-ingress-integrator charm.
+    """
+    # We should now be able to connect to FINOS Legend through it's service-hostname (this bundle
+    # sets it to "legend-host"). In this test scenario, we don't have a resolver for it. One could
+    # configure the /etc/hosts file to have the line:
+    # 127.0.0.1 legend-host
+    # Having the line above would resolve the hostname. For the current testing purposes, we
+    # can simply connect to 127.0.0.1 and having the hostname as a header. This is the
+    # equivalent of:
+    # curl --header 'Host: legend-host' http://127.0.0.1
+
+    for app_name in LEGEND_APPS:
+        url = "http://127.0.0.1%s" % APP_ROUTES[app_name]
+        headers = {"Host": LEGEND_HOST}
+        can_connect = check_legend_connection(app_name, url, headers)
+
+        assert can_connect, "Could not reach %s through its service-hostname." % app_name
+
+        logger.info("Successfully reached %s through its service-hostname.", app_name)
+
+
+@pytest.mark.abort_on_fail
+async def test_config_another_hostname(ops_test: pytest_plugin.OpsTest):
+    """Set a different hostname for the Legend Applications.
+
+    After setting a different application hostname, the gitlab-integrator get-redirect-uris
+    action results should update accordingly, and the Legend Applications should respond to
+    the new hostname.
+    """
+    for app_name in LEGEND_APPS_CONFIG:
+        app = ops_test.model.applications[app_name]
+        await app.set_config({"external-hostname": ANOTHER_LEGEND_HOST})
+
+    # Wait for the Legend applications to become Active.
+    for app_name in LEGEND_APPS_CONFIG:
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+        assert ops_test.model.applications[app_name].units[0].workload_status == "active"
+
+    for app_name in LEGEND_APPS:
+        url = "http://127.0.0.1%s" % APP_ROUTES[app_name]
+        headers = {"Host": ANOTHER_LEGEND_HOST}
+        can_connect = check_legend_connection(app_name, url, headers)
+
+        assert can_connect, "Could not reach %s through its new service-hostname." % app_name
+
+        logger.info("Successfully reached %s through its new service-hostname.", app_name)
+
+    gitlab_integrator = ops_test.model.applications["gitlab-integrator"]
+    action = await gitlab_integrator.units[0].run_action("get-redirect-uris")
+    action = await action.wait()
+
+    expected_uris = [
+        "http://%s/engine/callback" % ANOTHER_LEGEND_HOST,
+        "http://%s/api/auth/callback" % ANOTHER_LEGEND_HOST,
+        "http://%s/api/pac4j/login/callback" % ANOTHER_LEGEND_HOST,
+        "http://%s/studio/log.in/callback" % ANOTHER_LEGEND_HOST,
+    ]
+
+    assert "completed" == action.data.get("status")
+    assert expected_uris == action.data.get("results").get("result", "").split("\n")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,66 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint, integration
+
+[vars]
+tst_path = {toxinidir}/tests/
+all_path = {[vars]tst_path}
+
+[testenv]
+basepython = python3
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib
+  PYTHONBREAKPOINT=ipdb.set_trace
+passenv =
+  PYTHONPATH
+  HOME
+  PATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
+  HTTP_PROXY
+  HTTPS_PROXY
+  NO_PROXY
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]all_path}
+    black {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    black
+    flake8
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
+commands =
+    # pflake8 wrapper suppports config from pyproject.toml
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
+
+[testenv:integration]
+description = Run integration tests
+passenv =
+    GITLAB_CLIENT_ID
+    GITLAB_CLIENT_SECRET
+deps =
+    pytest
+    juju
+    pytest-operator
+    tenacity
+    requests
+    ops >= 1.2.0
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Adds the linting and integration test github workflows which will be triggered when a PR is created, when it merges, and when a manual workflow is dispatched.

The integration tests expect the ``GITLAB_CLIENT_ID`` and ``GITLAB_CLIENT_SECRET`` env variables to be set.

The integration tests will deploy the locally defined ``bundle.yaml`` on ``microk8s``, configures the necessary ``gitlab-client-id`` and ``gitlab-client-secret`` config options for ``gitlab-integrator``. The integration tests will expect that the deployed units become active, that FINOS Legend Engine, SDLC, and Studio are reachable through their IPs and through the default ``legend-host`` ``external-hostname`` configured. The Legend applications should be reachable through a newly configured ``external-hostname``.