### PR TITLE
WIP: Adds create-overlay job

### DIFF
--- a/.github/workflows/create_overlay.yaml
+++ b/.github/workflows/create_overlay.yaml
@@ -1,0 +1,84 @@
+name: Create FINOS Legend release overlay
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'The release to create an overlay for (yyyy-mm-dd)'
+        type: string
+        required: true
+      engine-image:
+        description: 'The FINOS Legend Engine image used in the overlay'
+        type: string
+        required: true
+      sdlc-image:
+        description: 'The FINOS Legend SDLC image used in the overlay'
+        type: string
+        required: true
+      studio-image:
+        description: 'The FINOS Legend Studio image used in the overlay'
+        type: string
+        required: true
+
+jobs:
+  create-overlay:
+    name: Create release overlay.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - id: release-short
+        run: |
+          # Use - as a delimiter, and get only the year and month (first 2 fields).
+          yyyy_mm=$(echo ${{ github.event.inputs.release }} | cut -d- -f1-2)
+          echo "::set-output name=yyyy_mm::$yyyy_mm"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: "edge"
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo snap install charmcraft --classic
+
+      - name: Update bundle.yaml
+        run: |
+          # Create an overlay yaml file with the desired release version for Legend Engine,
+          # SDLC, and Studio, and apply it over the bundle.yaml file.
+          overlay_file="overlay-$${{ github.event.inputs.release }}.yaml"
+          echo "applications:" > $overlay_file
+          echo "  legend-engine:" >> $overlay_file
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> $overlay_file
+          echo "    resources:" >> $overlay_file
+          echo "      engine-image: ${{ github.event.inputs.engine_image }}" >> $overlay_file
+          echo "  legend-sdlc:" >> $overlay_file
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}" }}/edge" >> $overlay_file
+          echo "    resources:" >> $overlay_file
+          echo "      sdlc-image: ${{ github.event.inputs.sdlc_image }}" >> $overlay_file
+          echo "  legend-studio:" >> $overlay_file
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> $overlay_file
+          echo "    resources:" >> $overlay_file
+          echo "      studio-image: ${{ github.event.inputs.studio_image }}" >> $overlay_file
+
+      - name: Create commit
+        uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+        with:
+          # The arguments for the `git add` command (see the paragraph below for more info)
+          # Default: '.'
+          add: 'overlay-$${{ github.event.inputs.release }}.yaml'
+
+          # The name of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_name: Claudiu Belu
+
+          # The email of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_email: cbelu@cloudbasesolutions.com
+
+          # Additional arguments for the git commit command. The --message argument is already set by the message input.
+          # Default: ''
+          commit: --signoff
+
+          # The message for the commit.
+          # Default: 'Commit from GitHub Actions (name of the workflow)'
+          message: "Creates ${{ github.event.inputs.release }} release overlay.yaml file"

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -13,15 +13,72 @@ jobs:
     name: Create release branch
     runs-on: ubuntu-latest
     steps:
+      - id: release-short
+        run: |
+          # Use - as a delimiter, and get only the year and month (first 2 fields).
+          yyyy_mm=$(echo ${{ github.event.inputs.release }} | cut -d- -f1-2)
+          echo "::set-output name=yyyy_mm::$yyyy_mm"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: "edge"
           fetch-depth: 0
 
-      - name: Create branch
-        uses: peterjgrainger/action-create-branch@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        run: |
+          sudo snap install yq
+          sudo snap install charmcraft --classic
+
+      - name: Update bundle.yaml
+        run: |
+          # Create an overlay yaml file with the desired release version for Legend Engine,
+          # SDLC, and Studio, and apply it over the bundle.yaml file.
+          echo "applications:" > overlay.yaml
+          echo "  legend-sdlc:" >> overlay.yaml
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}" }}/edge" >> overlay.yaml
+          echo "  legend-engine:" >> overlay.yaml
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> overlay.yaml
+          echo "  legend-studio:" >> overlay.yaml
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> overlay.yaml
+
+          # We can't have bundle.yaml as both the source and destionation, the result will not be
+          # as we would have wanted it.
+          cp bundle.yaml bundle2.yaml
+          yq eval-all '. as $item ireduce ({}; . *+ $item)' bundle2.yaml overlay.yaml > bundle.yaml
+
+          cat bundle.yaml
+
+      - name: Create branch and commit
+        uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
         with:
-          branch: "release-${{ github.event.inputs.release }}"
+          # The arguments for the `git add` command (see the paragraph below for more info)
+          # Default: '.'
+          add: 'bundle.yaml'
+
+          # The name of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_name: Claudiu Belu
+
+          # The email of the user that will be displayed as the author of the commit.
+          # Default: depends on the default_author input
+          author_email: cbelu@cloudbasesolutions.com
+
+          # Additional arguments for the git commit command. The --message argument is already set by the message input.
+          # Default: ''
+          commit: --signoff
+
+          # The message for the commit.
+          # Default: 'Commit from GitHub Actions (name of the workflow)'
+          message: "Creates ${{ github.event.inputs.release }} release"
+
+          # If this input is set, the action will push the commit to a new branch with this name.
+          # Default: ''
+          new_branch: "release-${{ github.event.inputs.release }}"
+
+      - name: Upload bundle to edge
+        uses: canonical/charming-actions/upload-bundle@1.0.2
+        with:
+          credentials: "${{ secrets.CHARMHUB_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.release-short.outputs.yyyy_mm }}/edge"

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -44,6 +44,7 @@ jobs:
             img_name="$3"
             release_version="$4"
 
+            release_short=$(echo "${release_version" | cut -d- -f1-2)
             release_file="${GITHUB_WORKSPACE}/legend/releases/${release_version}/manifest.json"
 
             # Getting the release version.
@@ -63,9 +64,7 @@ jobs:
             # Get the last revision number and image revision number and release.
             charm_rev=$(charmcraft revisions "${charm_name}" | awk 'FNR == 2 {print $1}')
             img_rev=$(charmcraft resource-revisions "${charm_name}" "${charm_resource}" | awk 'FNR == 2 {print $1}')
-            # TODO: Currently, we are not able to create new channels automatically. When we can,
-            # uncomment the following command.
-            #charmcraft release "${charm_name}" --revision=${charm_rev} --channel="${release_version}/edge" --resource="${charm_resource}:${img_rev}"
+            charmcraft release "${charm_name}" --revision=${charm_rev} --channel="${release_short}/edge" --resource="${charm_resource}:${img_rev}"
 
             # Also release it as the latest.
             charmcraft release "${charm_name}" --revision=${charm_rev} --channel=edge --resource="${charm_resource}:${img_rev}"

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -88,4 +88,14 @@ jobs:
             # create a commit that will make bundle.yaml point towards this release, and publish
             # the bundle into Charmhub.
             gh workflow run create_release.yaml -f release="${release}"
+
+            # Create an overlay.yaml file for this release.
+            release_file="${GITHUB_WORKSPACE}/legend/releases/${release}/manifest.json"
+            engine_version=$(cat "${release_file}" | jq --raw-output ".core.\"finos/legend-engine-server\"")
+            sdlc_version=$(cat "${release_file}" | jq --raw-output ".core.\"finos/legend-sdlc-server\"")
+            studio_version=$(cat "${release_file}" | jq --raw-output ".core.\"finos/legend-studio\"")
+            gh workflow run create_release.yaml -f release="${release}" \
+              -f engine-image="finos/legend-engine-server:${engine_version}" \
+              -f sdlc-image="finos/legend-sdlc-server:${sdlc_version}" \
+              -f studio-image="finos/legend-studio:${studio_version}"
           done

--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ juju add-model legend
 After setting up Juju on the Kubernetes of your choice:
 ```bash
 # Deploy the bundle:
-juju deploy finos-legend-bundle
+juju deploy finos-legend-bundle --channel=edge
+```
+
+The above command will deploy the latest application bundle published.
+You can deploy a specific version based on a [FINOS Legend release](https://github.com/finos/legend)
+by its year and month (newer than 2022.04.01):
+
+```bash
+juju deploy finos-legend-bundle --channel=2022-04/edge
 ```
 
 The above should yield a model containing all the Legend apps in either


### PR DESCRIPTION
If there are 2 releases in the same month, only the second one would be deployable through ``juju deploy finos-legend-bundle --channel=yyyy-mm/edge``. If a user would want to deploy the first release, they would have to override the Legend Images used.

This commit adds a github action that will create an ``overlay-yyyy-mm-dd.yaml`` file which can be used to explicitly deploy that version of FINOS Legend by running:

```
juju deploy finos-legend-bundle --channel=yyyy-mm/edge --overlay overlay-yyyy-mm-dd.yaml
```

This github action can be manually triggered, and it is triggered by the ``publish-images`` github action for new Legend Releases.