### PR TITLE
Fixes the Charmhub token docs

### DIFF
--- a/docs/CharmhubPublishing.md
+++ b/docs/CharmhubPublishing.md
@@ -9,7 +9,7 @@ charmcraft login --export=secrets-legend.auth \
   --charm=finos-legend-engine-k8s --charm=finos-legend-sdlc-k8s \
   --charm=finos-legend-studio-k8s --bundle=finos-legend-bundle \
   --permission=package-manage --permission=package-view-revisions \
-  --channel=edge --ttl=1576800
+  --ttl=1576800
 ```
 
 This token will have to be updated periodically since it has a certain time to live set.


### PR DESCRIPTION
Currently, the docs specifies to only create a token for the edge channel, however, we also publish charms into ``yyyy-mm/edge`` channels. We need a token that has permissions to do so.