### PR TITLE
Fixes integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,5 @@ jobs:
           microk8s-addons: "storage dns rbac ingress"
 
       - name: Run integration tests
-        env:
-          GITLAB_CLIENT_ID: "${{ secrets.GITLAB_CLIENT_ID }}"
-          GITLAB_CLIENT_SECRET: "${{ secrets.GITLAB_CLIENT_SECRET }}"
         run: |
           tox -vve integration

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -3,8 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
-import sys
 
 import pytest
 import requests
@@ -39,15 +37,8 @@ APP_ROUTES = {
     STUDIO_APP_NAME: "/studio",
 }
 
-GITLAB_CLIENT_ID = os.getenv("GITLAB_CLIENT_ID")
-GITLAB_CLIENT_SECRET = os.getenv("GITLAB_CLIENT_SECRET")
-
-if not all([GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET]):
-    logger.fatal(
-        "Cannot run the integration tests without GITLAB_CLIENT_ID and GITLAB_CLIENT_SECRET "
-        "environment variables. They are required for the FINOS Legend authentication."
-    )
-    sys.exit(1)
+GITLAB_CLIENT_ID = "fake-client-id"
+GITLAB_CLIENT_SECRET = "fake-client-secret"
 
 
 async def cli_deploy_bundle(ops_test, name):

--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,6 @@ commands =
 
 [testenv:integration]
 description = Run integration tests
-passenv =
-    GITLAB_CLIENT_ID
-    GITLAB_CLIENT_SECRET
 deps =
     pytest
     juju

--- a/tox.ini
+++ b/tox.ini
@@ -50,12 +50,14 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
+# NOTE: pytest-operator has been constrained due to the following:
+# https://github.com/charmed-kubernetes/pytest-operator/issues/72
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
     juju
-    pytest-operator
+    pytest-operator<0.17.0
     tenacity
     requests
     ops >= 1.2.0


### PR DESCRIPTION
The integration tests only test that the Legend applications are reachable, which doesn't require valid ``GITLAB_CLIENT_ID`` and ``GITLAB_CLIENT_SECRET`` configurations.

This is required because we won't be able to get the ``GITLAB_CLIENT_ID`` and ``GITLAB_CLIENT_SECRET`` repository secrets on pull_request (they are fetched from the repository that makes the pull request), which means that it would fail.