### PR TITLE
Fixes bundle publishing job

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -36,7 +36,7 @@ jobs:
           # SDLC, and Studio, and apply it over the bundle.yaml file.
           echo "applications:" > overlay.yaml
           echo "  legend-sdlc:" >> overlay.yaml
-          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}" }}/edge" >> overlay.yaml
+          echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> overlay.yaml
           echo "  legend-engine:" >> overlay.yaml
           echo "    channel: ${{ steps.release-short.outputs.yyyy_mm }}/edge" >> overlay.yaml
           echo "  legend-studio:" >> overlay.yaml
@@ -77,8 +77,13 @@ jobs:
           new_branch: "release-${{ github.event.inputs.release }}"
 
       - name: Upload bundle to edge
-        uses: canonical/charming-actions/upload-bundle@1.0.2
-        with:
-          credentials: "${{ secrets.CHARMHUB_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.release-short.outputs.yyyy_mm }}/edge"
+        # TODO: replace with  canonical/charming-actions/upload-bundle once the following issue
+        # is resolved: https://github.com/canonical/charming-actions/issues/40
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+        run: |
+          charmcraft pack
+          charmcraft upload finos-legend-bundle.zip
+          # Get the last revision number and image revision number and release.
+          bundle_rev=$(charmcraft revisions finos-legend-bundle | awk 'FNR == 2 {print $1}')
+          charmcraft release finos-legend-bundle --revision=${bundle_rev} --channel="${{ steps.release-short.outputs.yyyy_mm }}/edge"


### PR DESCRIPTION
We're manually packing and uploading the bundle instead of using the ``upload-bundle`` action because of an issue [1]. This will have to be updated later, when the issue is resolved.

[1] https://github.com/canonical/charming-actions/issues/40