### PR TITLE
Update docs with increased TTL charmcraft creds.

### DIFF
--- a/docs/CharmhubPublishing.md
+++ b/docs/CharmhubPublishing.md
@@ -9,7 +9,7 @@ charmcraft login --export=secrets-legend.auth \
   --charm=finos-legend-engine-k8s --charm=finos-legend-sdlc-k8s \
   --charm=finos-legend-studio-k8s --bundle=finos-legend-bundle \
   --permission=package-manage --permission=package-view-revisions \
-  --ttl=1576800
+  --ttl=15780000
 ```
 
 This token will have to be updated periodically since it has a certain time to live set.


### PR DESCRIPTION
Update the documentation with an increased time-to-live for the
charmcraft login credentials. The new TTL is 6 months replacing the old
value of 18 days. This attenuates certificate expiration issues.