### PR TITLE
Disable rewrite for nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -41,6 +41,8 @@ applications:
     channel: "stable"
     scale: 1
     trust: true
+    options:
+      rewrite-enabled: false
 
 relations:
   # Legend DB relations:


### PR DESCRIPTION
Adds `rewrite-enabled: false` to the legend-ingress application so that
the path doesn't get rewritten to the default path (`/`).