### PR TITLE
Send an email if the publish images job failed

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Runs everyday at 00:00. (see https://crontab.guru)
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   publish-images:
@@ -110,3 +110,15 @@ jobs:
              -f sdlc-image="finos/legend-sdlc-server:${sdlc_version}" \
              -f studio-image="finos/legend-studio:${studio_version}"
           done
+      - name: Send Email on Failure
+        if: failure()
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: ${{ secrets.EMAIL_SERVER }}
+          server_port: ${{ secrets.EMAIL_PORT }}
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          subject: "${{ github.job }} job of ${{ github.repository }} has failed"
+          body: "${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          to: ${{ secrets.EMAIL_TO }}
+          from: ${{ secrets.EMAIL_FROM }}

--- a/docs/CharmhubPublishing.md
+++ b/docs/CharmhubPublishing.md
@@ -13,9 +13,9 @@ charmcraft login --export=secrets-legend.auth \
   --ttl=15780000
 ```
 
-This token will have to be updated periodically since it has a certain time to live set. If the `charmcraft` process fails with the message "Provided credentials are no longer valid for Charmhub. Regenerate them and try again.", it means you have to export the secrets again by logging in to charmcraft using the instructions written above. 
+This token will have to be updated periodically since it has a certain time to live set. If the `charmcraft` process fails with the message "Provided credentials are no longer valid for Charmhub. Regenerate them and try again.", it means you have to export the secrets again by logging in to charmcraft using the instructions written above.
 
-By using the following `gh` commands you can skip going through each of the repositories settings to set the secret token: 
+By using the following `gh` commands you can skip going through each of the repositories settings to set the secret token:
 
 ```bash
 gh -R finos/legend-juju-bundle secret set CHARMHUB_TOKEN < secrets-legend.auth
@@ -26,4 +26,4 @@ gh -R finos/legend-juju-gitlab-integrator secret set CHARMHUB_TOKEN < secrets-le
 gh -R finos/legend-juju-db-operator secret set CHARMHUB_TOKEN < secrets-legend.auth
 ```
 
-The ``Publish Legend Images`` action will trigger the ``Create FINOS Legend release branch`` [action](../.github/workflows/create_release.yaml), which will create a new branch in the repository for the new release. This action can also be manually dispatched. But in order for this action chain to work, the ``GH_TOKEN`` repository secret needs to be added. The token can be [generated](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the ``repo, workflow`` scopes.
+The ``Publish Legend Images`` action will trigger the ``Create FINOS Legend release branch`` [action](../.github/workflows/create_release.yaml), which will create a new branch in the repository for the new release. This action can also be manually dispatched. But in order for this action chain to work, the ``GH_TOKEN`` repository secret needs to be added. The token can be [generated](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the ``repo, workflow`` scopes. The action will also send an email in case of failure, so it needs email related secrets to be set up as well: `EMAIL_SERVER`, `EMAIL_PORT`, `EMAIL_USERNAME`, `EMAIL_PASSWORD`, `EMAIL_TO`, `EMAIL_FROM`.


### PR DESCRIPTION
In order for the email to be sent successfully, the secrets used by the email job must be set.

Also includes some small code style fixes for the 2 affected files.