### PR TITLE
Fixes lint job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,13 @@ commands =
     isort {[vars]all_path}
     black {[vars]all_path}
 
+# TODO: remove the flake8 constraint after this issue is resolved:
+# https://github.com/savoirfairelinux/flake8-copyright/issues/19
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8 < 6.0.0
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
It seems that there are some issues when using the 6.0.0 pylint, resulting in the following errors:

```
...
    self._current_group.add_argument(*option_args, **option_kwargs)
  File "/usr/lib/python3.8/argparse.py", line 1385, in add_argument
    raise ValueError('%r is not callable' % (type_func,))
ValueError: 'int' is not callable
```

Puting an upper constraint fixes the issue.