### PR TITLE
edge: Sets rewrite-enabled to false for the nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -51,6 +51,8 @@ applications:
     channel: "edge"
     scale: 1
     trust: true
+    options:
+      rewrite-enabled: false
 
 relations:
   # Legend DB relations:


### PR DESCRIPTION
Newer revisions of the ``nginx-ingress-integrator`` charm now sets the ``rewrite-enabled`` option to ``True`` by default, which we don't want. We need that option to be off in order to access Legend Engine, SDLC, Studio.