### PR TITLE
main: Pins mongodb-k8s charm to revision 16

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9,6 +9,7 @@ applications:
   mongodb:
     charm: "mongodb-k8s"
     channel: "edge"
+    revision: 16
     scale: 1
 
   legend-db:


### PR DESCRIPTION
The published revision 17 provides different relations, which do not match the legend-db charm's required relations.

(cherry picked from commit a621253e0c0ae863f98543334db60aa0af5113c2)