### PR TITLE
Sets all the Legend Applications to the same hostname

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -5,6 +5,9 @@ name: finos-legend-bundle
 
 bundle: kubernetes
 
+variables:
+  external-hostname: &external-hostname "legend-host"
+
 applications:
   mongodb:
     charm: "mongodb-k8s"
@@ -20,16 +23,22 @@ applications:
     charm: "finos-legend-sdlc-k8s"
     channel: "stable"
     scale: 1
+    options:
+      external-hostname: *external-hostname
 
   legend-engine:
     charm: "finos-legend-engine-k8s"
     channel: "stable"
     scale: 1
+    options:
+      external-hostname: *external-hostname
 
   legend-studio:
     charm: "finos-legend-studio-k8s"
     channel: "stable"
     scale: 1
+    options:
+      external-hostname: *external-hostname
 
   gitlab-integrator:
     charm: "finos-legend-gitlab-integrator-k8s"


### PR DESCRIPTION
The Legend Applications are being deployed together. We can set their external-hostname config option to point towards the same hostname, which will then be served by the nginx ingress integrator charm.

(cherry picked from commit cb1b54cc2423042333b9528f260e34f6c604c50c)