### PR TITLE
Pin mongodb-k8s charm version for release 2022 04 04

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9,6 +9,7 @@ applications:
   mongodb:
     charm: "mongodb-k8s"
     channel: "edge"
+    revision: 16
     scale: 1
 
   legend-db:


### PR DESCRIPTION
Pin mongodb-k8s charm version for previous Legend bundle release.