### PR TITLE
integration: Pins juju to 3.1 for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          juju-channel: 3.1/stable
+          channel: 1.27-strict/stable
           microk8s-addons: "storage dns rbac ingress"
 
       - name: Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju < 3.2.0
     pytest-operator
     tenacity
     requests


### PR DESCRIPTION
Currently, the Juju client version installed for the integration tests is 2.9, while the Python Juju library is unpinned (currently installed version: 3.2). Because of this, the integration tests are failing with the following error [1]:

```
juju.errors.JujuConnectionError: juju server-version 2.9.44 not supported
```

Pins the installed version of juju to 3.1, which is the same as the version mentioned in the Juju Legend deployment guide.

Additionally, switches microk8s version to ``1.27-strict/stable``, as juju 3.0 and newer requires microk8s to be strictly confined.

Constrains the Python juju to lower than 3.2.

[1] https://github.com/finos/legend-juju-bundle/actions/runs/5809373229/job/15748021952?pr=46

xref: https://github.com/finos/legend-juju-bundle/pull/45

(cherry picked from commit 672e0fa235d38a72d5637edd0760ae0515a3c8db)