### PR TITLE
edge: Fixes integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,7 @@ jobs:
         run: python -m pip install tox
 
       - name: Setup operator environment
-        # TODO: change this to charmed-kubernetes/actions-operator@main once
-        # the following issue is addressed:
-        # https://github.com/charmed-kubernetes/actions-operator/issues/32
-        uses: claudiubelu/actions-operator@main
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           microk8s-addons: "storage dns rbac ingress"

--- a/tests/integration/test_bundle.py
+++ b/tests/integration/test_bundle.py
@@ -61,7 +61,7 @@ async def cli_deploy_bundle(ops_test, name):
 # is why we should retry the connection a few times.
 @tenacity.retry(
     retry=tenacity.retry_if_result(lambda x: x is False),
-    stop=tenacity.stop_after_attempt(10),
+    stop=tenacity.stop_after_attempt(15),
     wait=tenacity.wait_exponential(multiplier=1, min=5, max=30),
 )
 def check_legend_connection(app_name, url, headers=None):
@@ -128,8 +128,8 @@ async def test_config_gitlab(ops_test: pytest_plugin.OpsTest):
         "http://%s/studio/log.in/callback" % LEGEND_HOST,
     ]
 
-    assert "completed" == action.data.get("status")
-    assert expected_uris == action.data.get("results").get("result", "").split("\n")
+    assert "completed" == action.status
+    assert expected_uris == action.results.get("result", "").split("\n")
 
 
 @pytest.mark.abort_on_fail
@@ -215,5 +215,5 @@ async def test_config_another_hostname(ops_test: pytest_plugin.OpsTest):
         "http://%s/studio/log.in/callback" % ANOTHER_LEGEND_HOST,
     ]
 
-    assert "completed" == action.data.get("status")
-    assert expected_uris == action.data.get("results").get("result", "").split("\n")
+    assert "completed" == action.status
+    assert expected_uris == action.results.get("result", "").split("\n")

--- a/tox.ini
+++ b/tox.ini
@@ -50,14 +50,12 @@ commands =
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-# NOTE: pytest-operator has been constrained due to the following:
-# https://github.com/charmed-kubernetes/pytest-operator/issues/72
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
     juju
-    pytest-operator<0.17.0
+    pytest-operator
     tenacity
     requests
     ops >= 1.2.0


### PR DESCRIPTION
Unpins pytest-operator, the issue mentioned has been fixed and released. We've updated to juju v3.0, and thus, the juju actions work a bit differently.

Increases the network connectivity timeout.

(cherry picked from commit 15fe42445784578d771db732f02850507b2bec41)

xref: https://github.com/finos/legend-juju-bundle/pull/33