### PR TITLE
edge: Sets rewrite-enabled to false for the nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -40,6 +40,9 @@ applications:
     channel: "edge"
     scale: 1
     trust: true
+    options:
+      rewrite-enabled: false
+
 relations:
   # Legend DB relations:
   - ["legend-db", "mongodb"]


### PR DESCRIPTION
Newer revisions of the nginx-ingress-integrator charm now sets the rewrite-enabled option to True by default, which we don't want. We need that option to be off in order to access Legend Engine, SDLC, Studio.

(cherry picked from commit 1ca7572a88ddc9e2840b15b657cf47993ba4882e)

xref: https://github.com/finos/legend-juju-bundle/pull/35