### PR TITLE
actions: Fixes existing release check for publishing action

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -77,8 +77,9 @@ jobs:
            do
             echo "Treating ${release}..."
             # If the current release was already published, skip.
-            if git show-ref --verify --quiet "refs/heads/release-${release}"
+            if git show-ref --verify --quiet "refs/remotes/origin/release-${release}"
             then
+              echo "Release ${release} already exists. Skipping."
               continue
             fi
 


### PR DESCRIPTION
Currently, we're checking if a release was already treated by checking if the repository has a branch for that release. However, the current check verifies if the branch exists locally, not on the origin remote.

This commit addresses this issue.