### PR TITLE
integration: Pins juju to 3.1 for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
         uses: claudiubelu/actions-operator@main
         with:
           provider: microk8s
+          juju-channel: 3.1/stable
+          channel: 1.27-strict/stable
           microk8s-addons: "storage dns rbac ingress"
 
       - name: Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju < 3.2.0
     pytest-operator
     tenacity
     requests


### PR DESCRIPTION
Pins the installed version of juju to 3.1.

Additionally, switches microk8s version to 1.27-strict/stable, as juju 3.0 and newer requires microk8s to be strictly confined.

Updated the Python juju dependency.

(cherry picked from commit 91b26291873fd8286c75110e4f5590af18d90d78)

xref: https://github.com/finos/legend-juju-bundle/pull/45