### PR TITLE
edge: Pins nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -49,6 +49,7 @@ applications:
   legend-ingress:
     charm: "nginx-ingress-integrator"
     channel: "edge"
+    revision: 79
     scale: 1
     trust: true
     options:


### PR DESCRIPTION
Pins the ``nginx-ingress-integrator`` charm. The ingress relation is currently deprecated, and may be removed in the future, breaking the bundle.