### PR TITLE
main: Pins nginx-ingress-integrator charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -49,6 +49,7 @@ applications:
   legend-ingress:
     charm: "nginx-ingress-integrator"
     channel: "stable"
+    revision: 79
     scale: 1
     trust: true
     options:


### PR DESCRIPTION
Pins the ``nginx-ingress-integrator`` charm. The ingress relation is currently deprecated, and may be removed in the future, breaking the bundle.

(cherry picked from commit 1d6841c72befb8ff4a13c96460bccd79c1b8064d)