### PR TITLE
Adds latest/ prefix to mongodb charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -11,7 +11,7 @@ variables:
 applications:
   mongodb:
     charm: "mongodb-k8s"
-    channel: "edge"
+    channel: "latest/edge"
     revision: 16
     scale: 1
 


### PR DESCRIPTION
Required in order to pick the proper channel.

This will fix the currently failing integration tests [1].

[1] https://github.com/finos/legend-juju-bundle/actions/runs/9055249583/job/24876090500#step:5:487

(cherry picked from commit 242775e4c36ec89579eb8538921f7beb99f64d08)