### PR TITLE
Adds latest/ prefix to mongodb charm

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7,7 +7,7 @@ variables:
 applications:
   mongodb:
     charm: "mongodb-k8s"
-    channel: "edge"
+    channel: "latest/edge"
     revision: 16
     scale: 1
   legend-db:


### PR DESCRIPTION
Required in order to pick the proper channel.

(cherry picked from commit 242775e4c36ec89579eb8538921f7beb99f64d08)